### PR TITLE
fix version of Antminer S9

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -61,6 +61,7 @@ CGMinerClient.prototype.connect = function () {
 
   return this.version()
     .then(function (version) {
+      version.CGMiner = version.CGMiner || version.BMMiner;
       return require('./apis/parser').parse(version.CGMiner);
     })
     .then(function (commands) {


### PR DESCRIPTION
Antminer S9 uses BMMiner instead of CGMiner.